### PR TITLE
specify notification sender bundle id on Mac OS X

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -57,7 +57,8 @@ if (process.platform == 'darwin') {
       title: title,
       message: message,
       wait: true,
-      icon: path.join(__dirname, '../resource/icon.png')
+      icon: path.join(__dirname, '../resource/icon.png'),
+      sender: "com.electron.net.tsinghua"
     });
   };
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4240346/10709182/258fd3c0-7a55-11e5-8a5f-ab269d21ead2.png)
